### PR TITLE
Revert AL-Go test change

### DIFF
--- a/.github/workflows/PublishToAppSource.yaml
+++ b/.github/workflows/PublishToAppSource.yaml
@@ -38,7 +38,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@aholstrup1/v8.3-bridge-issue-2278
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v8.3
         with:
           shell: pwsh
 
@@ -47,7 +47,7 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@aholstrup1/v8.3-bridge-issue-2278
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v8.3
         with:
           shell: pwsh
 
@@ -60,20 +60,20 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@aholstrup1/v8.3-bridge-issue-2278
+        uses: microsoft/AL-Go-Actions/ReadSettings@v8.3
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@aholstrup1/v8.3-bridge-issue-2278
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v8.3
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'appSourceContext'
 
       - name: Deliver
-        uses: microsoft/AL-Go/Actions/Deliver@aholstrup1/v8.3-bridge-issue-2278
+        uses: microsoft/AL-Go-Actions/Deliver@v8.3
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -94,7 +94,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@aholstrup1/v8.3-bridge-issue-2278
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v8.3
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
This reverts the AL-Go test change from `9609995a28b05be29ebe8b52bbcbed8b0f7a22f1` so the repository returns to the prior workflow configuration.

The branch contains a single standard revert commit for `Test AL-Go change (#32)`.